### PR TITLE
Prevent karma parser from eliding multiple increments

### DIFF
--- a/karma/parser.py
+++ b/karma/parser.py
@@ -66,7 +66,7 @@ def parse_message(message: str, db_session: Session):
     # Hold on tight because this will be a doozy...
     karma_re_target = r"(?P<karma_target>([^\"\s]+)|(\"([^\"]+)\"))"
     karma_re_op = r"(?P<karma_op>[+-]{2,})"
-    karma_re_reason = '(\s(because|for)\s+((?P<karma_reason>[^",]+)|"(?P<karma_reason_2>.+)")($|,)|\s\((?P<karma_reason_3>.+)\)|\s"(?P<karma_reason_4>.+)"(?![+-]{2,})|,?\s|$)'
+    karma_re_reason = '(\s(because|for)\s+((?P<karma_reason>[^",]+)|"(?P<karma_reason_2>.+)")($|,)|\s\((?P<karma_reason_3>.+)\)|\s"(?P<karma_reason_4>[^"]+)"(?![+-]{2,})|,?\s|$)'
 
     karma_regex = re.compile(karma_re_target + karma_re_op + karma_re_reason)
     items = karma_regex.finditer(filtered_message)

--- a/tests/test_karma_parser.py
+++ b/tests/test_karma_parser.py
@@ -239,6 +239,16 @@ def test_complex_multiple_karma_no_reasons_quotes(database):  # The Sinjo input
     ]
 
 
+def test_complex_multiple_karma_no_reasons_quotes_no_comma_separation(database):
+    assert parse_message(
+        '"easy lover"++ "phil collins"++ "philip bailey"++', database
+    ) == [
+        RawKarma(name="easy lover", op="++", reason=None),
+        RawKarma(name="phil collins", op="++", reason=None),
+        RawKarma(name="philip bailey", op="++", reason=None),
+    ]
+
+
 def test_complex_multiple_karma_with_reasons_and_quotes(database):
     assert parse_message(
         'Foobar++ because baz blat, "Hello world"-- for "foo, bar"', database


### PR DESCRIPTION
The issue was that the karma_reason_4 group expanded until it hit the first double-quote not followed by a [+-]{2}.

The fix is turning an "any character" requirement into a "any non-double-quote character"