### PR TITLE
Add filter to karma transactions

### DIFF
--- a/karma/karma.py
+++ b/karma/karma.py
@@ -9,7 +9,12 @@ from sqlalchemy_utils import ScalarListException
 
 from cogs.commands.admin import MiniKarmaMode
 from karma.parser import parse_message_content
-from karma.transaction import KarmaTransaction, apply_blacklist, make_transactions
+from karma.transaction import (
+    KarmaTransaction,
+    apply_blacklist,
+    filter_transactions,
+    make_transactions,
+)
 from models import Karma, KarmaChange, MiniKarmaChannel, User
 from utils import get_name_string
 
@@ -25,6 +30,7 @@ def process_karma(message: Message, message_id: int, db_session: Session, timeou
     # Parse the message for karma modifications
     karma_items = parse_message_content(message.content)
     transactions = make_transactions(karma_items, message)
+    transactions = filter_transactions(transactions)
     transactions = apply_blacklist(transactions, db_session)
 
     # If no karma'd items, just return

--- a/karma/transaction.py
+++ b/karma/transaction.py
@@ -65,6 +65,25 @@ def make_transactions(
     return [KarmaTransaction.from_item(i, message) for i in truncated]
 
 
+def filter_transactions(
+    transactions: Iterable[KarmaTransaction],
+) -> List[KarmaTransaction]:
+    def pred(transaction: KarmaTransaction) -> bool:
+        return not (
+            # Short items must be bypassed
+            (
+                len(transaction.karma_item.topic) < 3
+                and not transaction.karma_item.bypass
+            )
+            # Whitespace items are not allowed
+            or transaction.karma_item.topic.isspace()
+            # Empty items are not allowed
+            or len(transaction.karma_item.topic) == 0
+        )
+
+    return [t for t in transactions if pred(t)]
+
+
 def apply_blacklist(
     transactions: Iterable[KarmaTransaction], db_session: Session
 ) -> List[KarmaTransaction]:


### PR DESCRIPTION
This filters out:
- Zero-length karma items
- Karma items with only whitespace topics
- Items less than length 3 that are not escaped