### PR TITLE
Roll error message fix and cleanup

### DIFF
--- a/roll/ast.py
+++ b/roll/ast.py
@@ -603,21 +603,20 @@ class Program:
 
     def reduce(self):
         """Intentionally does not use the @trace decorator"""
-        self.hash_vars()
+        self.hash_vars(self.counter, {})
         out = [let.reduce(self.environment, self.counter) for let in self.lets]
         return out
 
-    def hash_vars(self):
-        """Intentionally does not use the @trace decorator"""
-        map = {}
+    @trace
+    def hash_vars(self, counter, map):
         for a in self.assignments:
-            map[a.name] = self.counter.next_id
-            a.identifier = self.counter.next_id
-            self.counter.pop_id()
+            map[a.name] = counter.next_id
+            a.identifier = counter.next_id
+            counter.pop_id()
         for a in self.assignments:
-            a.expression.hash_vars(self.counter, map)
+            a.expression.hash_vars(counter, map)
         for e in self.expressions:
-            e.hash_vars(self.counter, map)
+            e.hash_vars(counter, map)
 
     def __str__(self):
         if len(self.expressions) == 1:

--- a/roll/exceptions.py
+++ b/roll/exceptions.py
@@ -6,9 +6,11 @@ from utils.exceptions import InternalError, WarningError
 
 def trace2log(trace):
     trace = trace[1:]  # The first element is always an empty let statement
-    if len(trace) > 5: # Limit the size of the trace to reduce error message size
+    if len(trace) > 5:  # Limit the size of the trace to reduce error message size
         trace = trace[:2] + ["..."] + trace[-3:]
-    out = "Exception in\n    " + "\nin\n    ".join([clean_brackets(str(t)) for t in reversed(trace)])
+    out = "Exception in\n    " + "\nin\n    ".join(
+        [clean_brackets(str(t)) for t in reversed(trace)]
+    )
     return out
 
 

--- a/roll/exceptions.py
+++ b/roll/exceptions.py
@@ -1,11 +1,14 @@
 from abc import ABC, abstractmethod
 
+from utils import clean_brackets
 from utils.exceptions import InternalError, WarningError
 
 
 def trace2log(trace):
     trace = trace[1:]  # The first element is always an empty let statement
-    out = "Exception in\n    " + "\nin\n    ".join([str(t) for t in reversed(trace)])
+    if len(trace) > 5: # Limit the size of the trace to reduce error message size
+        trace = trace[:2] + ["..."] + trace[-3:]
+    out = "Exception in\n    " + "\nin\n    ".join([clean_brackets(str(t)) for t in reversed(trace)])
     return out
 
 

--- a/roll/exceptions.py
+++ b/roll/exceptions.py
@@ -28,7 +28,7 @@ class UndefinedIdentifierError(RunTimeError):
         self, trace, identifier, message="'{id}' is not defined in scope\n{trace}"
     ):
         self.message = message.format(trace=trace2log(trace), id=identifier)
-        super().__init__(self.message)
+        super().__init__([], self.message)
 
 
 class CaseFailureError(RunTimeError):

--- a/tests/test_clean_brackets.py
+++ b/tests/test_clean_brackets.py
@@ -1,0 +1,38 @@
+import pytest
+
+from utils import clean_brackets
+
+DEFAULT_CASES = [
+    ("", ""),
+    ("()", ""),
+    ("(abc)", "abc"),
+    ("((def))", "def"),
+    ("(xyz", "(xyz"),
+    ("lmn)", "lmn)"),
+    ("[]", "[]"),
+    ("<abc>", "<abc>"),
+    ("{xyz", "{xyz"),
+    ("lmn`", "lmn`"),
+]
+
+
+CUSTOM_CASES = [
+    ("", [("(", ")")], ""),
+    ("(<asdf>)", [], "(<asdf>)"),
+    ("(<mixed>)", [("<", ">")], "(<mixed>)"),
+    ("(<mixed>)", [("<", ">"), ("(", ")")], "mixed"),
+    ("<(mixed)>", [("<", ">"), ("(", ")")], "mixed"),
+    ("aaaaa", [("a", "a")], "a"),
+]
+
+
+@pytest.mark.parametrize(["string", "expected"], DEFAULT_CASES)
+def test_defaults(string, expected):
+    actual = clean_brackets(string)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(["string", "brackets", "expected"], CUSTOM_CASES)
+def test_customs(string, expected, brackets):
+    actual = clean_brackets(string, brackets)
+    assert actual == expected

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,1 @@
-from utils.utils import get_name_string, is_decimal, pluralise
+from utils.utils import get_name_string, is_decimal, pluralise, clean_brackets

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,1 @@
-from utils.utils import get_name_string, is_decimal, pluralise, clean_brackets
+from utils.utils import clean_brackets, get_name_string, is_decimal, pluralise

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -35,7 +35,15 @@ def filter_out_none(iterable: Iterable):
     return [i for i in iterable if i is not None]
 
 
-def clean_brackets(str, brackets=[("(", ")"),]):
-    while (str[0], str[-1]) in brackets:
+def clean_brackets(
+    str,
+    brackets=[
+        ("(", ")"),
+    ],
+):
+    """Removes matching brackets from the outside of a string
+    Only supports single-character brackets
+    """
+    while len(str) > 1 and (str[0], str[-1]) in brackets:
         str = str[1:-1]
     return str

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -33,3 +33,9 @@ def pluralise(l, word, single="", plural="s"):
 
 def filter_out_none(iterable: Iterable):
     return [i for i in iterable if i is not None]
+
+
+def clean_brackets(str, brackets=[("(", ")"),]):
+    while (str[0], str[-1]) in brackets:
+        str = str[1:-1]
+    return str


### PR DESCRIPTION
- Fixes one case of an error message being mangled
- Fixes an inconsistency in error traces
- Limits the length of the error trace in error messages
- Adds a clean_brackets command to remove matching brackets from strings
- Adds texts for clean_brackets