### PR TITLE
Add task loop to report OpenAI API costs

### DIFF
--- a/cogs/commands/chatgpt.py
+++ b/cogs/commands/chatgpt.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone, date
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
+
 import aiohttp
 import discord
 import openai


### PR DESCRIPTION
AI is fun but expensive so I thought this would be amusing to report.
The API endpoint used is undocumented, but works for now.
Another random API is used for USD -> GBP conversion.
The channel list is pulled from `config.ai_chat_channels`, and all of those channels get their descriptions reset every half an hour.
