### PR TITLE
Fetch recreate webhook from portainer

### DIFF
--- a/cogs/commands/system.py
+++ b/cogs/commands/system.py
@@ -117,9 +117,8 @@ Started {started} (uptime {uptime})"""
             resp = await session.post(url)
             if not resp.ok:
                 status = resp.status
-                err_msg = (
-                    f"Failed to update. {status} from Portainer API: {resp.text()}"
-                )
+                msg = (await resp.json())["message"]
+                err_msg = f"Failed to update. {status} from Portainer API: {msg}"
                 logging.error(err_msg)
                 await ctx.reply(err_msg)
                 # remove our event that just failed to happen

--- a/cogs/commands/system.py
+++ b/cogs/commands/system.py
@@ -16,8 +16,8 @@ from models.models import db_session
 from models.system import EventKind, SystemEvent
 from utils import is_compsoc_exec_in_guild
 
-APOLLO_JSON_URL = (
-    "https://portainer.uwcs.co.uk/api/endpoints/2/docker/containers/apollo/json"
+APOLLO_ENDPOINT_URL = (
+    "https://portainer.uwcs.co.uk/api/endpoints/2/docker/containers/apollo"
 )
 
 
@@ -88,12 +88,11 @@ Started {started} (uptime {uptime})"""
     async def restart(self, ctx: Context[Bot]):
         headers = {"X-API-Key": f"{CONFIG.PORTAINER_API_KEY}"}
         async with aiohttp.ClientSession(headers=headers) as session:
-            url = "https://portainer.uwcs.co.uk/api/endpoints/2/docker/containers/apollo/restart"
             event = SystemEvent(EventKind.RESTART, ctx.message.id, ctx.channel.id)
             db_session.add(event)
             db_session.commit()
             await ctx.reply("Going down for reboot...")
-            resp = await session.post(url)
+            resp = await session.post(f"{APOLLO_ENDPOINT_URL}/restart")
             if not resp.ok:
                 status = resp.status
                 msg = (await resp.json())["message"]
@@ -170,7 +169,7 @@ Started {started} (uptime {uptime})"""
     async def get_docker_json() -> dict[Any, Any] | None:
         headers = {"X-API-Key": f"{CONFIG.PORTAINER_API_KEY}"}
         async with aiohttp.ClientSession(headers=headers) as session:
-            resp = await session.get(APOLLO_JSON_URL)
+            resp = await session.get(f"{APOLLO_ENDPOINT_URL}/json")
             if not resp.ok:
                 logging.error("Could not reach Portainer API")
                 return None
@@ -180,7 +179,7 @@ Started {started} (uptime {uptime})"""
 async def setup(bot: Bot):
     headers = {"X-API-Key": f"{CONFIG.PORTAINER_API_KEY}"}
     async with aiohttp.ClientSession(headers=headers) as session:
-        resp = await session.get(APOLLO_JSON_URL)
+        resp = await session.get(f"{APOLLO_ENDPOINT_URL}/json")
     match (resp.ok, (environ.get("CONTAINER") is not None)):
         case (True, True):
             await bot.add_cog(System(bot))

--- a/cogs/commands/system.py
+++ b/cogs/commands/system.py
@@ -118,7 +118,7 @@ Started {started} (uptime {uptime})"""
             # Construct URL
             webhook_url = f"https://portainer.uwcs.co.uk/api/webhooks/{webhook_token}"
             logging.info(f"Recreate webhook url {webhook_url}")
-            
+
             event = SystemEvent(EventKind.UPDATE, ctx.message.id, ctx.channel.id)
             db_session.add(event)
             db_session.commit()

--- a/config/config.py
+++ b/config/config.py
@@ -26,7 +26,6 @@ class Config:
         self.AI_CHAT_CHANNELS: list[int] = parsed.get("ai_chat_channels")
         self.AI_SYSTEM_PROMPT: str = parsed.get("ai_system_prompt")
         self.PORTAINER_API_KEY: str = parsed.get("portainer_api_key")
-        self.PORTAINER_WEBHOOK_URL: str = parsed.get("portainer_webhook_url")
 
         # Configuration
         self.LOG_LEVEL: str = parsed.get("log_level")


### PR DESCRIPTION
Removes hardcoded in config as a restart through the gui changes the webhook. Has to use a bit of a chain of requests to fetch, but works so 🤷