### PR TITLE
Replace isort with Ruff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,16 +39,18 @@ jobs:
           pip install --user pipenv
           pipenv sync --dev
 
-      - name: Check formatting with isort and black
+      - name: Check formatting with black
         run: |
-          pipenv run isort --check-only --diff --skip __tests__ .
           pipenv run black --check --diff --exclude __tests__ .
+
+      - name: Check code style with ruff
+        run: |
+          pipenv run ruff check .
 
       - name: Check types with pyright
         if: always()
         run: |
           pipenv run pyright --verbose
-
 
   test:
     name: Run Tests with Pytest

--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,6 @@ psycopg = {extras = ["binary"], version = "~=3.1"}
 
 [dev-packages]
 black = "~=22.12"
-isort = "~=5.11"
 pytest = "~=6.2"
 pretend = "~=1.0"
 pyright = "==1.1.303"

--- a/Pipfile
+++ b/Pipfile
@@ -33,6 +33,7 @@ isort = "~=5.11"
 pytest = "~=6.2"
 pretend = "~=1.0"
 pyright = "==1.1.303"
+ruff = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "12366313dbc80b2db5b521b776e1c9ef42756171d456c5adba220b73e6e16479"
+            "sha256": "ddbe7436d48ecf42368b394d0d7a9c67e218643e8f79547c992140bb16d7e8b6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1859,6 +1859,30 @@
             "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==6.2.5"
+        },
+        "ruff": {
+            "hashes": [
+                "sha256:0d9ab6ad16742eb78919e0fba09f914f042409df40ad63423c34bb20d350162a",
+                "sha256:1d2a60c102e7a5e147b58fc2cbea12a563c565383effc527c987ea2086a05742",
+                "sha256:2933cc9631f453305399c7b8fb72b113ad76b49ae1d7103cc4afd3a423bed164",
+                "sha256:45866048d1dcdcc80855998cb26c4b2b05881f9e043d2e3bfe1aa36d9a2e8f28",
+                "sha256:5473a4c6cac34f583bff08c5f63b8def5599a0ea4dc96c0302fbd2cc0b3ecbad",
+                "sha256:5977ce304da35c263f5e082901bd7ac0bd2be845a8fcfd1a29e4d6680cddb307",
+                "sha256:6c48926156288b8ac005eb1db5e77c15e8a37309ae49d9fb6771d5cf5f777590",
+                "sha256:72a087712d474fa17b915d7cb9ef807e1256182b12ddfafb105eb00aeee48d1a",
+                "sha256:72a3a0936369b986b0e959f9090206ed3c18f9e5e439ea5b8e6867c6707aded5",
+                "sha256:770c5eb6376de024111443022cda534fb28980a9dd3b4abc83992a8770167ba6",
+                "sha256:7ce67736cd8dfe97162d1e7adfc2d9a1bac0efb9aaaff32e4042c7cde079f54b",
+                "sha256:80effdf4fe69763d69eb4ab9443e186fd09e668b59fe70ba4b49f4c077d15a1b",
+                "sha256:a8c6ad6b9cd77489bf6d1510950cbbe47a843aa234adff0960bae64bd06c3b6d",
+                "sha256:b02aae62f922d088bb01943e1dbd861688ada13d735b78b8348a7d90121fd292",
+                "sha256:de44fbc6c3b25fccee473ddf851416fd4e246fc6027b2197c395b1b3b3897921",
+                "sha256:e6b1c961d608d373a032f047a20bf3c55ad05f56c32e7b96dcca0830a2a72348",
+                "sha256:f572c4296d8c7ddd22c3204de4031965be524fdd1fdaaef273945932912b28c5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==0.0.285"
         },
         "setuptools": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddbe7436d48ecf42368b394d0d7a9c67e218643e8f79547c992140bb16d7e8b6"
+            "sha256": "fff0e59174afb08b922aa2010bf5e7caa3049ff15edd8d6227b184065bed0069"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1768,15 +1768,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
-        },
-        "isort": {
-            "hashes": [
-                "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
-                "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
-            ],
-            "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==5.12.0"
         },
         "mypy-extensions": {
             "hashes": [

--- a/cogs/commands/announce.py
+++ b/cogs/commands/announce.py
@@ -144,7 +144,7 @@ class Announcements(commands.Cog):
             db_session.query(Announcement)
             .filter(
                 Announcement.trigger_at >= datetime.datetime.now(),
-                Announcement.triggered == False,
+                Announcement.triggered is False,
             )
             .all()
         )
@@ -261,7 +261,7 @@ async def announcement_check(bot):
         now = datetime.datetime.now()
         announcements = (
             db_session.query(Announcement)
-            .filter(Announcement.trigger_at <= now, Announcement.triggered == False)
+            .filter(Announcement.trigger_at <= now, Announcement.triggered is False)
             .all()
         )
 
@@ -403,7 +403,7 @@ async def add_announcement(ctx, channel, trigger_time, announcement_content):
     except (ScalarListException, SQLAlchemyError) as e:
         db_session.rollback()
         logging.exception(e)
-        await ctx.send(f"Something went wrong")
+        await ctx.send("Something went wrong")
 
 
 async def setup(bot: Bot):

--- a/cogs/commands/chatgpt.py
+++ b/cogs/commands/chatgpt.py
@@ -10,11 +10,7 @@ from discord import AllowedMentions
 from discord.ext import commands, tasks
 from discord.ext.commands import (
     Bot,
-    BucketType,
     Context,
-    Cooldown,
-    check,
-    clean_content,
 )
 
 from cogs.commands.openaiadmin import is_author_banned_openai
@@ -112,11 +108,14 @@ class ChatGPT(commands.Cog):
         gpt4 = False
 
         # If a message in the chain triggered a !chat or !prompt or /chat
-        is_cmd = (
-            lambda m: m.content.startswith(chat_cmd)
-            or m.content.startswith(prompt_cmd)
-            or (m.interaction is not None and m.interaction.name == "chat")
-        )
+        def is_cmd(m):
+            return (
+                m.content.startswith(chat_cmd)
+                or m.content.startswith(prompt_cmd)
+                or m.interaction is not None
+                and m.interaction.name == "chat"
+            )
+
         if not any(map(is_cmd, message_chain)):
             return
 

--- a/cogs/commands/counting.py
+++ b/cogs/commands/counting.py
@@ -42,7 +42,7 @@ class Counting(Cog):
             self.channel = ctx.channel
             started_at = datetime.utcnow()
 
-            await ctx.send(f"The game begins!")
+            await ctx.send("The game begins!")
             # The count starts at 0.
             count = 0
             # The number of successful replies in a row.

--- a/cogs/commands/karma.py
+++ b/cogs/commands/karma.py
@@ -278,7 +278,7 @@ class Karma(commands.Cog):
         )
 
         # Construct the response string
-        result = f"The 5 most karma'd topics and their total karma are:\n\n"
+        result = "The 5 most karma'd topics and their total karma are:\n\n"
         for karma in most_karma:
             result += f" • **{karma.name}** being karma'd a total number of {karma.total_karma} times\n"
         result += "\nWhere equal scores, karma is sorted alphabetically. :scales:"
@@ -564,7 +564,7 @@ class Karma(commands.Cog):
                 )
                 result = f'The {reasons_plural} for "{karma_stripped}" are as follows:\n\n{bullet_points}'
             else:
-                result = f"There are no reasons down for that karma topic! :frowning:"
+                result = "There are no reasons down for that karma topic! :frowning:"
 
             file = None
             fp = None

--- a/cogs/commands/karma_admin.py
+++ b/cogs/commands/karma_admin.py
@@ -6,7 +6,6 @@ from discord.ext import commands
 from discord.ext.commands import Bot, Context, check
 from sqlalchemy.exc import SQLAlchemyError
 
-from cogs.commands.karma import current_milli_time
 from models import db_session
 from models.channel_settings import IgnoredChannel, MiniKarmaChannel
 from utils import EnumGet, get_database_user, is_compsoc_exec_in_guild

--- a/cogs/commands/misc.py
+++ b/cogs/commands/misc.py
@@ -1,5 +1,4 @@
 import random
-import subprocess
 
 from discord.ext import commands
 from discord.ext.commands import Bot, Context

--- a/cogs/commands/openaiadmin.py
+++ b/cogs/commands/openaiadmin.py
@@ -6,7 +6,6 @@ from models import db_session
 from models.openai import OpenAIBans
 from models.user import User as db_user
 from utils import get_database_user, get_database_user_from_id, is_compsoc_exec_in_guild
-from utils.typing import Identifiable
 
 LONG_HELP_TEXT = """
 Exec-only command to stop or reallow a user from usinf openAI functionality in apollo (Dalle and ChatGPT)

--- a/cogs/commands/quotes.py
+++ b/cogs/commands/quotes.py
@@ -157,7 +157,6 @@ def add_quote(author: Mention, quote, time, session=db_session) -> str:
 def delete_quote(
     is_exec, requester: Mention, query: QuoteID, session=db_session
 ) -> str:
-
     quote = quotes_query(query, session).one_or_none()
 
     if quote is None:
@@ -180,7 +179,6 @@ def delete_quote(
 def update_quote(
     is_exec, requester: Mention, quote_id: QuoteID, new_text, session=db_session
 ) -> str:
-
     quote = quotes_query(quote_id, session).one_or_none()
 
     if quote is None:
@@ -366,7 +364,6 @@ class Quotes(commands.Cog):
             target = f"{ctx.prefix}{ctx.command}"
             reference = ctx.message.reference
             if content == target and reference:
-
                 replied_message = await ctx.channel.fetch_message(reference.message_id)
 
                 await self.quote_discord_user(
@@ -545,7 +542,6 @@ class Quotes(commands.Cog):
             message = [quote_str(q) for q in quotes]
 
         # Split if too long
-        prev = ctx.message
         for msg in split_into_messages(message):
             await ctx.send(msg, allowed_mentions=AllowedMentions().none())
 

--- a/cogs/commands/reminders.py
+++ b/cogs/commands/reminders.py
@@ -103,7 +103,7 @@ class Reminders(commands.Cog):
         except (ScalarListException, SQLAlchemyError) as e:
             db_session.rollback()
             logging.exception(e)
-            return {"content": f"Something went wrong with the database"}
+            return {"content": "Something went wrong with the database"}
 
     @reminder.command()
     async def list(self, ctx: Context):
@@ -115,7 +115,7 @@ class Reminders(commands.Cog):
             db_session.query(Reminder)
             .filter(
                 Reminder.trigger_at >= datetime.now(),
-                Reminder.triggered == False,
+                Reminder.triggered is False,
                 Reminder.user_id == author.id,
             )
             .all()

--- a/cogs/commands/rolemenu.py
+++ b/cogs/commands/rolemenu.py
@@ -7,7 +7,6 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from models import db_session
 from models.role_menu import RoleEntry, RoleMenu
-from models.user import User
 from utils import is_compsoc_exec_in_guild, rerun_to_confirm
 from utils.announce_utils import get_long_msg
 
@@ -299,7 +298,7 @@ class RoleMenuCog(commands.Cog):
         try:
             channel = guild.get_channel(menu.channel_id)
             msg = await channel.fetch_message(menu.message_id)
-        except discord.errors.NotFound as e:
+        except discord.errors.NotFound:
             return None, menu
         return msg, menu
 
@@ -309,7 +308,7 @@ class RoleMenuCog(commands.Cog):
             guild = self.bot.get_guild(gid)
             channel = guild.get_channel(cid)
             msg = await channel.fetch_message(mid)
-        except discord.errors.NotFound as e:
+        except discord.errors.NotFound:
             return None
         return msg
 

--- a/cogs/commands/roomsearch.py
+++ b/cogs/commands/roomsearch.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 from datetime import date, datetime, time, timedelta
-from io import BytesIO
 from pathlib import Path
 from urllib.parse import quote
 
@@ -84,7 +83,6 @@ class RoomSearch(commands.Cog):
             room = rooms[0]  # Only one in rooms
 
         print(room)
-        ext_ref = room.get("extRef") or {}
         # if not mini:
         # Room info
         embed = discord.Embed(
@@ -151,7 +149,6 @@ class RoomSearch(commands.Cog):
         #     )
         # else:
         #     embed.set_thumbnail(url="attachment://map.png")
-        msg = await ctx.reply(embed=embed)  # , file=img)
 
     def get_map_url(self, room):
         """Constructs url for campus map for room"""
@@ -272,11 +269,14 @@ class RoomSearch(commands.Cog):
         # Check for user react on msg
         async def check_reacts():
             try:
-                check = (
-                    lambda r, u: r.message.id == conf_message.id
-                    and u == ctx.message.author
-                    and str(r.emoji) in emojis
-                )
+
+                def check(r, u):
+                    return (
+                        r.message.id == conf_message.id
+                        and u == ctx.message.author
+                        and str(r.emoji) in emojis
+                    )
+
                 react_emoji, _ = await ctx.bot.wait_for(
                     "reaction_add", check=check, timeout=30
                 )

--- a/cogs/commands/roomsearch.py
+++ b/cogs/commands/roomsearch.py
@@ -83,6 +83,7 @@ class RoomSearch(commands.Cog):
             room = rooms[0]  # Only one in rooms
 
         print(room)
+        # ext_ref = room.get("extRef") or {}
         # if not mini:
         # Room info
         embed = discord.Embed(
@@ -149,6 +150,8 @@ class RoomSearch(commands.Cog):
         #     )
         # else:
         #     embed.set_thumbnail(url="attachment://map.png")
+
+        await ctx.reply(embed=embed)  # , file=img)
 
     def get_map_url(self, room):
         """Constructs url for campus map for room"""

--- a/cogs/commands/run.py
+++ b/cogs/commands/run.py
@@ -30,7 +30,7 @@ class Language(Enum):
             case "sh":
                 return Language.Sh
             case "":
-                raise Exception(f"No language provided!")
+                raise Exception("No language provided!")
             case _:
                 raise Exception(f"Language '{lang}' not supported!")
 
@@ -95,7 +95,6 @@ class Run(commands.Cog):
         json_request = {"code": code, "lang": str(language.value), "input": input}
 
         async with ctx.typing():
-
             async with aiohttp.ClientSession() as session:
                 run_endpoint = CONFIG.PYROMANIAC_URL + "/api/run"
                 response = await session.post(run_endpoint, json=json_request)

--- a/cogs/commands/system.py
+++ b/cogs/commands/system.py
@@ -142,7 +142,7 @@ Started {started} (uptime {uptime})"""
         # check for any unacknowledged events
         all_events = db_session.scalars(
             select(SystemEvent)
-            .where(SystemEvent.acknowledged == False)
+            .where(SystemEvent.acknowledged is False)
             .order_by(desc(SystemEvent.time))
         ).all()
         if len(all_events) == 0:

--- a/cogs/commands/tex.py
+++ b/cogs/commands/tex.py
@@ -65,7 +65,7 @@ class Tex(commands.Cog):
 
         # Load the image as a file to be attached to an image
         img_file = File(img, filename="tex.png")
-        await ctx.reply(f"Here you go! :abacus:", file=img_file)
+        await ctx.reply("Here you go! :abacus:", file=img_file)
 
 
 async def setup(bot: Bot):

--- a/cogs/commands/vote.py
+++ b/cogs/commands/vote.py
@@ -1,11 +1,7 @@
-import sqlite3
 from datetime import datetime, timedelta, timezone
 
-import discord
 from discord.ext import commands
-from discord.ext.commands import Bot, CommandInvokeError, Context, clean_content
-from discord.ext.commands.errors import CommandError
-from sqlalchemy.exc import SQLAlchemyError
+from discord.ext.commands import Bot, Context, clean_content
 
 from models import db_session
 from models.votes import DiscordVoteMessage

--- a/cogs/commands/xkcd.py
+++ b/cogs/commands/xkcd.py
@@ -5,7 +5,6 @@ from discord.ext import commands
 from discord.ext.commands import Bot, Context
 
 import utils
-from config import CONFIG
 
 LONG_HELP_TEXT = """
 For all your xkcd needs

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from pathlib import Path
 from random import choice, choices
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,4 @@
-from config.config import CONFIG  # type: ignore
+# this is reported as unused but actually is used
+# because apollo is multiple 'unrelated' modules, rather than a single module
+# TODO: fix this
+from config.config import CONFIG  # type: ignore  # noqa: F401

--- a/models/models.py
+++ b/models/models.py
@@ -7,10 +7,6 @@ from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Session, mapped_c
 from config import CONFIG
 
 # this is bad, redo this
-engine = create_engine(CONFIG.DATABASE_CONNECTION, future=True)
-
-from config import CONFIG
-
 engine = create_engine(CONFIG.DATABASE_CONNECTION)
 if CONFIG.SQL_LOGGING:
     logging.basicConfig()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -56,3 +54,5 @@ reportMissingParameterType = false
 target-version = "py310"
 select = ["E", "F", "I"] # defaults plus isort
 ignore = ["E501"]
+
+exclude = ["migrations/versions/*", "models/__init__.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ ignore = [
   "roll/**/*",
   "tests/**/*",
   "voting/**/*",
-  "utils/custom_help.py"
+  "utils/custom_help.py",
 ]
 # https://microsoft.github.io/pyright/#/configuration?id=diagnostic-rule-defaults
 
@@ -51,3 +51,8 @@ useLibraryCodeForTypes = true
 reportMissingTypeStubs = false
 reportImportCycles = false         # this is actually a big issue but the bad module structure makes it hard to resolve
 reportMissingParameterType = false
+
+[tool.ruff]
+target-version = "py310"
+select = ["E", "F", "I"] # defaults plus isort
+ignore = ["E501"]

--- a/resources/rooms/source/room_conv.py
+++ b/resources/rooms/source/room_conv.py
@@ -9,8 +9,11 @@ import json
 
 def read_mapping(filename: str):
     with open(filename) as f:
-        l = [l.split(" | ") for l in f.readlines()]
-        return {x[0].strip(): x[1].strip() for x in l if len(x) > 1}
+        return {
+            x[0].strip(): x[1].strip()
+            for x in [ls.split(" | ") for ls in f.readlines()]
+            if len(x) > 1
+        }
 
 
 tabtonames = read_mapping("tabula-sciencianame.txt")

--- a/roll/parser.py
+++ b/roll/parser.py
@@ -1,9 +1,24 @@
+# ruff:  noqa: F821 some abuse of python's binding mechanism goes on here I think
 import re
 
 from parsita import ParseError, TextParsers, lit, opt, reg, rep, rep1, rep1sep, repsep
 from parsita.util import constant
 
-from roll.ast import *
+from roll.ast import (
+    Assignment,
+    Operator,
+    Program,
+    TokenApplication,
+    TokenCase,
+    TokenFunction,
+    TokenLet,
+    TokenNumber,
+    TokenOperator,
+    TokenRoll,
+    TokenString,
+    TokenTernary,
+    TokenVariable,
+)
 
 
 def bin_operator(xs):
@@ -113,10 +128,12 @@ def function(xs):
 
 
 class ProgramParser(TextParsers):
-
     # Actual grammar
-    split1 = lambda item, separator: item & rep(separator & item)
-    split = lambda item, separator: opt(split1(item, separator))
+    def split1(item, separator):
+        return item & rep(separator & item)
+
+    def split(item, separator):
+        return opt(split1(item, separator))
 
     identifier = reg(r"[a-zA-Z]\w*")
 

--- a/tests/test_karma.py
+++ b/tests/test_karma.py
@@ -2,8 +2,7 @@ import datetime as datetime_module
 from datetime import datetime
 
 from karma.karma import is_in_cooldown
-from models.karma import Karma, KarmaChange
-from models.user import User
+from models.karma import KarmaChange
 
 _TIMEOUT = 60
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,3 @@
+# ruff: noqa: F403 this is bad but fine ish
 from utils.DateTimeConverter import *
 from utils.utils import *

--- a/utils/announce_utils.py
+++ b/utils/announce_utils.py
@@ -18,7 +18,7 @@ try:
     subfont: ImageFont.ImageFont = ImageFont.truetype(
         "resources/Montserrat-Medium.ttf", 45
     )
-except OSError as e:
+except OSError:
     logging.warn("Error loading announcement title fonts")
     font, subfont = None, None
 

--- a/utils/custom_help.py
+++ b/utils/custom_help.py
@@ -12,16 +12,16 @@ class SimplePrettyHelp(commands.HelpCommand):
         """Main help menu"""
 
         cog_fields = []
-        for cog, commands in mapping.items():
+        for cog, cmds in mapping.items():
             name = getattr(cog, "qualified_name", "Others")
-            if name == "Misc" or not commands:
+            if name == "Misc" or not cmds:
                 continue
             cog_fields.append(
                 {
                     "name": name,
                     "value": "\n".join(
                         (f"⠀- `{command.name}` {command.brief or ''}")
-                        for command in commands
+                        for command in cmds
                     ),
                     "inline": False,
                 }

--- a/utils/mentions.py
+++ b/utils/mentions.py
@@ -55,5 +55,5 @@ class MentionConverter(commands.Converter[Any]):
             if uid is not None:
                 return Mention.id_mention(uid.id)
             return Mention.string_mention(argument)
-        except:
+        except Exception:
             return Mention.string_mention(argument)

--- a/voting/discord_interfaces/discord_base.py
+++ b/voting/discord_interfaces/discord_base.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, List, NamedTuple, Tuple, Union
 
 import discord
 from discord import AllowedMentions, ButtonStyle, InteractionMessage
-from discord.ext.commands import Bot, Context
+from discord.ext.commands import Context
 from discord.ui import Button, View
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -203,9 +203,9 @@ class DiscordBase:
     def parse_choices(self, args: List[str]) -> Tuple[str, List[str]]:
         """Parse title and choices out of args"""
         if len(args) > 256:
-            raise Exception(f"More than 256 choices given")
+            raise Exception("More than 256 choices given")
         if len(args) == 0:
-            raise Exception(f"No choices given")
+            raise Exception("No choices given")
 
         # Truncate each choice to 256 chars
         for i, c in enumerate(args):
@@ -242,8 +242,8 @@ class DiscordBase:
         self, lines: Union[List[str], List[Tuple[str, str]]], title: str = None
     ):
         """Construct embed from list of choices"""
-        if not type(lines) is tuple:
-            lines = [(l, "_ _") for l in lines]
+        if type(lines) is not tuple:
+            lines = [(ll, "_ _") for ll in lines]
         embed = discord.Embed(title=self.get_description() if title is None else title)
         for n, v in lines:
             if len(n) > 250:

--- a/voting/vote_types/base_vote.py
+++ b/voting/vote_types/base_vote.py
@@ -3,7 +3,6 @@ from typing import List, Tuple
 from sqlalchemy import func
 
 from models import db_session
-from models.user import User
 from models.votes import UserVote, Vote, VoteChoice, VoteType
 
 
@@ -92,7 +91,7 @@ class BaseVote:
         db_session.flush()
 
     def remove(self, vote):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 base_vote = BaseVote()


### PR DESCRIPTION
Ruff is the Hot New Thing in Python linting land. It can do what isort does, plus a lot more.  And it's written in Rust so we simply have to use it.

This PR replaces isort with ruff, and fixes all the lint issues raised by Ruff so that we can use it in CI and enforce some slightly nicer code style going forward.