### PR TITLE
Fix sqlalchemy filters

### DIFF
--- a/cogs/commands/announce.py
+++ b/cogs/commands/announce.py
@@ -144,7 +144,7 @@ class Announcements(commands.Cog):
             db_session.query(Announcement)
             .filter(
                 Announcement.trigger_at >= datetime.datetime.now(),
-                Announcement.triggered is False,
+                Announcement.triggered.is_(False),
             )
             .all()
         )
@@ -261,7 +261,7 @@ async def announcement_check(bot):
         now = datetime.datetime.now()
         announcements = (
             db_session.query(Announcement)
-            .filter(Announcement.trigger_at <= now, Announcement.triggered is False)
+            .filter(Announcement.trigger_at <= now, Announcement.triggered.is_(False))
             .all()
         )
 

--- a/cogs/commands/reminders.py
+++ b/cogs/commands/reminders.py
@@ -115,7 +115,7 @@ class Reminders(commands.Cog):
             db_session.query(Reminder)
             .filter(
                 Reminder.trigger_at >= datetime.now(),
-                Reminder.triggered is False,
+                Reminder.triggered.is_(False),
                 Reminder.user_id == author.id,
             )
             .all()

--- a/cogs/commands/system.py
+++ b/cogs/commands/system.py
@@ -142,7 +142,7 @@ Started {started} (uptime {uptime})"""
         # check for any unacknowledged events
         all_events = db_session.scalars(
             select(SystemEvent)
-            .where(SystemEvent.acknowledged is False)
+            .where(SystemEvent.acknowledged.is_(False))
             .order_by(desc(SystemEvent.time))
         ).all()
         if len(all_events) == 0:


### PR DESCRIPTION
After #225, SQLAlchemy `== False` filters were replaced with `is False` by Ruff. This is not the same thing and the queries will return no results. Replacing `is False` with `.is_(False)` resolves this and keeps the linter happy.