### PR TITLE
De-register as a command from apollo

### DIFF
--- a/apollo.py
+++ b/apollo.py
@@ -36,7 +36,8 @@ EXTENSIONS = [
     "cogs.commands.quotes",
     "cogs.commands.rolemenu",
     "cogs.commands.reminders",
-    "cogs.commands.roll",
+    # TODO: Roll has performance issues with large values, removing till stabilised
+    # "cogs.commands.roll",
     "cogs.commands.run",
     "cogs.commands.roomsearch",
     "cogs.commands.say",


### PR DESCRIPTION
The roll command crashes the Apollo bot when run with very large inputs (for example `(500d2)d1000`).

There is an ongoing issue to improve its performance (#237) but for now it should be disabled to improve Apollo's uptime.