### PR TITLE
Run `!roll` on a separate process (instead of thread) and with timeout.

### DIFF
--- a/cogs/commands/roll.py
+++ b/cogs/commands/roll.py
@@ -80,7 +80,9 @@ class Roll(commands.Cog):
         try:
             result = await asyncio.wait_for(future, DICE_TIMEOUT)
         except asyncio.TimeoutError:
-            result = TIMEOUT_OUT.format(ping=display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!")
+            result = TIMEOUT_OUT.format(
+                ping=display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!"
+            )
 
         await ctx.reply(result)
 
@@ -93,7 +95,9 @@ class Roll(commands.Cog):
         try:
             result = await asyncio.wait_for(future, DICE_TIMEOUT)
         except asyncio.TimeoutError:
-            result = TIMEOUT_OUT.format(ping=int.user.display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!")
+            result = TIMEOUT_OUT.format(
+                ping=int.user.display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!"
+            )
 
         await int.response.send_message(result)
 

--- a/cogs/commands/roll.py
+++ b/cogs/commands/roll.py
@@ -72,7 +72,6 @@ class Roll(commands.Cog):
         help=LONG_HELP_TEXT, brief=SHORT_HELP_TEXT, aliases=["r"], rest_is_raw=True
     )
     async def roll(self, ctx: Context, *, message: clean_content):
-        loop = asyncio.get_event_loop()
         display_name = get_name_string(ctx.message)
         p = await Parallelism.get(self.bot)
         future = p.execute_on_process(run, message, display_name)
@@ -88,7 +87,6 @@ class Roll(commands.Cog):
 
     @app_commands.command(name="roll", description=SHORT_HELP_TEXT)
     async def roll_slash(self, int: discord.Interaction, dice: str):
-        loop = asyncio.get_event_loop()
         p = await Parallelism.get(self.bot)
         future = p.execute_on_process(run, dice, int.user.display_name)
 

--- a/cogs/commands/roll.py
+++ b/cogs/commands/roll.py
@@ -56,6 +56,13 @@ INTERNAL_OUT = """
 {body}
 """
 
+TIMEOUT_OUT = """
+:hourglass: **DICE OUTTATIME** :hourglass:
+{ping} - **{error}**
+"""
+
+DICE_TIMEOUT = 3.0  # seconds
+
 
 class Roll(commands.Cog):
     def __init__(self, bot: Bot):
@@ -67,22 +74,28 @@ class Roll(commands.Cog):
     async def roll(self, ctx: Context, *, message: clean_content):
         loop = asyncio.get_event_loop()
         display_name = get_name_string(ctx.message)
-
-        def work():
-            return run(message, display_name)
-
         p = await Parallelism.get(self.bot)
-        p.send_to_ctx_after_threaded(work, ctx, loop)
+        future = p.execute_on_process(run, message, display_name)
+
+        try:
+            result = await asyncio.wait_for(future, DICE_TIMEOUT)
+        except asyncio.TimeoutError:
+            result = TIMEOUT_OUT.format(ping=display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!")
+
+        await ctx.reply(result)
 
     @app_commands.command(name="roll", description=SHORT_HELP_TEXT)
     async def roll_slash(self, int: discord.Interaction, dice: str):
         loop = asyncio.get_event_loop()
-
-        def work():
-            return run(dice, "")
-
         p = await Parallelism.get(self.bot)
-        p.send_to_int_after_threaded(work, int, loop)
+        future = p.execute_on_process(run, dice, int.user.display_name)
+
+        try:
+            result = await asyncio.wait_for(future, DICE_TIMEOUT)
+        except asyncio.TimeoutError:
+            result = TIMEOUT_OUT.format(ping=int.user.display_name, error=f"Ran out of time ({DICE_TIMEOUT}s)!")
+
+        await int.response.send_message(result)
 
 
 def run(message, display_name):


### PR DESCRIPTION
Fixes #237.