### PR TITLE
Added private_view input to hide response (only works on slash comman…

### DIFF
--- a/cogs/commands/summarise.py
+++ b/cogs/commands/summarise.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from typing import Optional
 
@@ -38,13 +39,19 @@ class Summarise(commands.Cog):
         prompt = f"""People yap too much, I don't want to read all of it. The topic is something related to {channel_name}. In 2 sentences or less give me the gist of what is being said. {bullet_points} Note that the messages are in reverse chronological order:
         """
         return prompt
+    
+    def optional_context_manager(self, use: bool, cm: callable):
+        if use:
+            return cm()
+        
+        return contextlib.nullcontext()
 
     @commands.cooldown(CONFIG.SUMMARISE_LIMIT, CONFIG.SUMMARISE_COOLDOWN * 60, commands.BucketType.channel)
     @commands.hybrid_command(help=LONG_HELP_TEXT, brief=SHORT_HELP_TEXT)
     async def tldr(
         self, ctx: Context, number_of_messages: int = 100, bullet_point_output: bool = False, private_view: bool = False):
         number_of_messages = 400 if number_of_messages > 400 else number_of_messages
-
+        
         # avoid banned users
         if not await is_author_banned_openai(ctx):
             await ctx.send("You are banned from OpenAI!")
@@ -56,11 +63,13 @@ class Summarise(commands.Cog):
         messages = await self.create_message(messages, prompt)
 
         # send the prompt to the ai overlords to process
-        async with ctx.typing():
+        async with self.optional_context_manager(not private_view, ctx.typing):
             response = await self.dispatch_api(messages)
             if response:
+                prev = ctx
                 for content in split_into_messages(response):
-                        await ctx.send(content, allowed_mentions=mentions, ephemeral=private_view)
+                    prev = await prev.reply(content, allowed_mentions=mentions, ephemeral=private_view)
+
 
     async def dispatch_api(self, messages) -> Optional[str]:
         logging.info(f"Making OpenAI request: {messages}")

--- a/cogs/commands/summarise.py
+++ b/cogs/commands/summarise.py
@@ -42,10 +42,9 @@ class Summarise(commands.Cog):
     @commands.cooldown(CONFIG.SUMMARISE_LIMIT, CONFIG.SUMMARISE_COOLDOWN * 60, commands.BucketType.channel)
     @commands.hybrid_command(help=LONG_HELP_TEXT, brief=SHORT_HELP_TEXT)
     async def tldr(
-        self, ctx: Context, number_of_messages: int = 100, bullet_point_output: bool = False ):
+        self, ctx: Context, number_of_messages: int = 100, bullet_point_output: bool = False, private_view: bool = False):
         number_of_messages = 400 if number_of_messages > 400 else number_of_messages
-        
-        
+
         # avoid banned users
         if not await is_author_banned_openai(ctx):
             await ctx.send("You are banned from OpenAI!")
@@ -60,9 +59,8 @@ class Summarise(commands.Cog):
         async with ctx.typing():
             response = await self.dispatch_api(messages)
             if response:
-                prev = ctx.message
                 for content in split_into_messages(response):
-                    prev = await prev.reply(content, allowed_mentions=mentions)
+                        await ctx.send(content, allowed_mentions=mentions, ephemeral=private_view)
 
     async def dispatch_api(self, messages) -> Optional[str]:
         logging.info(f"Making OpenAI request: {messages}")


### PR DESCRIPTION
Removed the use of .reply as it was causing errors with slash commands

Added feature to allow users (only while using slash commands) to privately get tldr response