### PR TITLE
Janky temporary solution for campus map links

### DIFF
--- a/cogs/commands/roomsearch.py
+++ b/cogs/commands/roomsearch.py
@@ -155,7 +155,7 @@ class RoomSearch(commands.Cog):
 
     def get_map_url(self, room):
         """Constructs url for campus map for room"""
-        return f"https://campus.warwick.ac.uk/?slid={room.get('extRef').get('id')}"
+        return f"https://warwick.ac.uk/sitebuilder2/api/campus_map/location/{room.get('_id')}"
 
     def get_info_url(self, room):
         """Constructs url for ITS info on room"""


### PR DESCRIPTION
Temporary fix for #286.

I was supprised to learn that the API for the old campus map still exists ([example](https://hub.smartne.com/api/store/projects/warwick/live/locations/search/ms.02)). The "_id" key in the response is what used to be used in the longer form of URLs that could be used to link to rooms. There are several Warwick services that will take this ID and translate it into a nearly always functional link to the new map. For example, `https://warwick.ac.uk/sitebuilder2/api/campus_map/location/ID_HERE`, which is what I used for this PR. 

However, sometimes the link it produces to the new campus map doesn't work, and the old map's API probably won't exist forever, so this will need to be replaced in the future.

It's worth noting that https://tabula.warwick.ac.uk/admin/scientia-rooms lists these IDs for each room that it supports.